### PR TITLE
renaming Option '--token' to '--auth'

### DIFF
--- a/codchi/src/cli.rs
+++ b/codchi/src/cli.rs
@@ -620,13 +620,13 @@ codchi module set <MACHINE_NAME> <MODULE_NAME> --url=my-project-name
         #[arg(long, short = 'p')]
         pub use_nixpkgs: Option<NixpkgsLocation>,
 
-        /// Authorisation token for private repositories. Generally, the syntax is `<user>:<token>`
+        /// Authorisation string for private repositories. Generally, the syntax is `<user>:<token>`
         /// or just `<token>`.
         ///
         /// GitHub for example has something like `ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
         /// whereas GitLab uses `oauth2:glpat-xxxxxxxxxxxxxxxxxxxx`.
         #[arg(long, short)]
-        pub token: Option<String>,
+        pub auth: Option<String>,
 
         /// The git branch to use for the code machine module.
         #[arg(long, short)]

--- a/codchi/src/module.rs
+++ b/codchi/src/module.rs
@@ -110,7 +110,7 @@ pub fn set(
     if opts.tag.is_none()
         && opts.commit.is_none()
         && opts.branch.is_none()
-        && opts.token.is_none()
+        && opts.auth.is_none()
         && opts.use_nixpkgs.is_none()
         && new_name.is_none()
         && module_path.is_none()
@@ -137,12 +137,12 @@ pub fn set(
     if cfg.nixpkgs_from.as_ref() == Some(module_name) {
         cfg.nixpkgs_from = Some(new_name.clone());
     }
-    let old_token = match old.location.clone() {
-        FlakeLocation::Remote { token, .. } => token,
+    let old_auth = match old.location.clone() {
+        FlakeLocation::Remote { auth, .. } => auth,
         FlakeLocation::Local { .. } => None,
     };
     let (url, new_module_path, opts) = if let Some(url) = url {
-        // if the URL changed, prompt if branch, token etc... stay the same
+        // if the URL changed, prompt if branch, auth etc... stay the same
         let keep_or_edit = |name: &str, value: Option<String>| -> Result<Option<String>> {
             let Some(value) = value else { return Ok(None) };
             if opts.dont_prompt {
@@ -178,10 +178,10 @@ pub fn set(
                 dont_prompt: opts.dont_prompt,
                 use_nixpkgs: opts.use_nixpkgs.clone(), // is prompted inside fetch_module
                 no_build: opts.no_build,
-                token: opts
-                    .token
+                auth: opts
+                    .auth
                     .clone()
-                    .map_or_else(|| keep_or_edit("token", old_token), |x| Ok(Some(x)))?,
+                    .map_or_else(|| keep_or_edit("auth", old_auth), |x| Ok(Some(x)))?,
                 branch: opts
                     .branch
                     .clone()
@@ -210,7 +210,7 @@ pub fn set(
                     }
                 }),
                 no_build: opts.no_build,
-                token: opts.token.clone().or(old_token),
+                auth: opts.auth.clone().or(old_auth),
                 branch: opts.branch.clone().or(old.r#ref.clone()),
                 tag: opts.branch.clone().or(old.r#ref.clone()),
                 commit: opts.commit.clone().or(old.commit.clone()),
@@ -478,10 +478,10 @@ fn inquire_module_url(
                 _ => unreachable!(),
             };
 
-            // Token in URL / port only work with git+http(s)
+            // Auth in URL / port only work with git+http(s)
             let (host, scheme) = if let Some(port) = url.port {
                 (format!("{host}:{port}"), fallback_scheme)
-            } else if opts.token.is_some() {
+            } else if opts.auth.is_some() {
                 (host, fallback_scheme)
             } else {
                 let guess = guess_scheme(&host);
@@ -525,7 +525,7 @@ fn inquire_module_url(
                     scheme,
                     host,
                     repo,
-                    token: opts.token.clone(),
+                    auth: opts.auth.clone(),
                 },
                 commit: opts.commit.clone(),
                 r#ref: opts.branch.as_ref().or(opts.tag.as_ref()).cloned(),
@@ -613,7 +613,7 @@ pub fn clone(
         let git_url = format!(
             "{scheme}://{auth}{host}/{repo}",
             auth = input_options
-                .token
+                .auth
                 .map(|t| format!("{t}@"))
                 .unwrap_or_default(),
             scheme = git_url.scheme,


### PR DESCRIPTION
The CLI option `--token` for the commands `codchi clone` and `codchi init` is, in my opinion, misleading. There are various formats depending on the Git hosting server, such as `<username>:<password>`, `<username>:<token>`, `oauth2:<token>`, or simply `<token>`. To improve clarity and indicate that the full authentication string must be provided, I would suggest renaming the option to `--auth`.